### PR TITLE
Prevent VS from always rebuilding projects that reference CefSharp when using AnyCPU platform, All props files

### DIFF
--- a/NuGet/CefSharp.Common.props
+++ b/NuGet/CefSharp.Common.props
@@ -1,29 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Reference Include="CefSharp" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="CefSharp.Core" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Core" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Core" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Platform)' == 'x86'">
+      <ItemGroup>
+        <Reference Include="CefSharp">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="CefSharp.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'x64'">
+      <ItemGroup>
+        <Reference Include="CefSharp">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+        <Reference Include="CefSharp.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Core.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'AnyCPU'">
+      <ItemGroup>
+        <Reference Include="CefSharp">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="CefSharp.Core">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Core.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/NuGet/CefSharp.OffScreen.props
+++ b/NuGet/CefSharp.OffScreen.props
@@ -1,18 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Reference Include="CefSharp.OffScreen" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.OffScreen.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.OffScreen" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.OffScreen.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.OffScreen" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.OffScreen.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Platform)' == 'x86'">
+      <ItemGroup>
+        <Reference Include="CefSharp.OffScreen">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.OffScreen.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'x64'">
+      <ItemGroup>
+        <Reference Include="CefSharp.OffScreen">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.OffScreen.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'AnyCPU'">
+      <ItemGroup>
+        <Reference Include="CefSharp.OffScreen">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.OffScreen.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>
-

--- a/NuGet/CefSharp.WinForms.props
+++ b/NuGet/CefSharp.WinForms.props
@@ -1,17 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Reference Include="CefSharp.WinForms" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.WinForms.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.WinForms" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.WinForms.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.WinForms" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.WinForms.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Platform)' == 'x86'">
+      <ItemGroup>
+        <Reference Include="CefSharp.WinForms">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.WinForms.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'x64'">
+      <ItemGroup>
+        <Reference Include="CefSharp.WinForms">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.WinForms.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'AnyCPU'">
+      <ItemGroup>
+        <Reference Include="CefSharp.WinForms">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.WinForms.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>

--- a/NuGet/CefSharp.Wpf.props
+++ b/NuGet/CefSharp.Wpf.props
@@ -1,17 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <Reference Include="CefSharp.Wpf" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Wpf" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Wpf.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="CefSharp.Wpf" Condition="'$(Platform)' == 'AnyCPU'">
-      <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(Platform)' == 'x86'">
+      <ItemGroup>
+        <Reference Include="CefSharp.Wpf">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'x64'">
+      <ItemGroup>
+        <Reference Include="CefSharp.Wpf">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x64\CefSharp.Wpf.dll</HintPath>
+          <Private>True</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'AnyCPU'">
+      <ItemGroup>
+        <Reference Include="CefSharp.Wpf">
+          <HintPath>$(MSBuildThisFileDirectory)..\CefSharp\x86\CefSharp.Wpf.dll</HintPath>
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>


### PR DESCRIPTION
I'm also having the same issue as @joaompneves with Visual Studio rebuilding every time projects that depend on CefSharp and use AnyCPU platform are built. I opened Issue #2077 to add more details and repro steps. 

I took @joaompneves' PR #2067 that fixes this issue and applied it to all the other .props files so that the issue is fixed for all references (common, core, Wpf, WinForms, OffScreen).

I hope this helps,